### PR TITLE
fix(IncludeDir): Include Directory Error

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -77,7 +77,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
                               'IlmThread' + version_suffix,
                               'Iex' + version_suffix,
                               'Half' + version_suffix]
-
+        
+        self.cpp_info.includedirs = [os.path.join('include', 'OpenEXR'), 'include']
         if self.options.shared and self.settings.os == "Windows":
             self.cpp_info.defines.append("OPENEXR_DLL")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -72,7 +72,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
         if self.settings.compiler == 'Visual Studio' and self.settings.build_type == 'Debug':
             version_suffix += "_d"
 
-        self.cpp_info.includedirs = [os.path.join('include', 'OpenEXR'), ]
         self.cpp_info.libs = ['IlmImf' + version_suffix,
                               'IlmImfUtil' + version_suffix,
                               'IlmThread' + version_suffix,


### PR DESCRIPTION
When subfolder OpenEXR is added to the include path, some libraries fail to compile because the expected access pattern is  "OpeEXR/... "